### PR TITLE
Adding AUTO_START flag for autocert-init docker image

### DIFF
--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -8,6 +8,8 @@ ENV CA_URL="ca.step.svc.cluster.local"
 
 ENV KUBE_LATEST_VERSION="v1.14.3"
 
+ENV AUTO_START=false
+
 USER root
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
  && chmod +x /usr/local/bin/kubectl

--- a/init/autocert.sh
+++ b/init/autocert.sh
@@ -3,8 +3,10 @@
 #set -x
 
 echo "Welcome to Autocert configuration. Press return to begin."
-read ANYKEY
 
+if [ "$AUTO_START" = false ] ; then
+    read ANYKEY
+fi
 
 STEPPATH=/home/step
 


### PR DESCRIPTION
### Description

Add and environment variable `AUTO_START` to avoid the need for a user to type a key when running the `kubectl run autocert-init -it --rm --image smallstep/autocert-init --restart Never`

### Why this is needed

- for automating the installation of autocert using `kubectl` commands on a bash script, ie: `kubectl run autocert-init -it --rm --image smallstep/autocert-init --env="AUTO_START=true" --restart Never`

💔Thank you!
