### PR TITLE
Prefer to use built-in base64 wrap (or nowrap).

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -146,7 +146,7 @@ webhooks:
         name: autocert
         namespace: step
         path: "/mutate"
-      caBundle: $(cat $(step path)/certs/root_ca.crt | base64)
+      caBundle: $(cat $(step path)/certs/root_ca.crt | base64 -w 0)
     rules:
       - operations: ["CREATE"]
         apiGroups: [""]

--- a/init/autocert.sh
+++ b/init/autocert.sh
@@ -123,8 +123,8 @@ kubectl apply -f https://raw.githubusercontent.com/smallstep/autocert/master/ins
 kubectl apply -f https://raw.githubusercontent.com/smallstep/autocert/master/install/03-rbac.yaml
 kubectl -n step rollout status deployment/autocert
 
-# Some `base64`s wrap lines... no thanks!
-CA_BUNDLE=$(cat $(step path)/certs/root_ca.crt | base64 | tr -d '\n')
+# -w means disable wrapping for `base64`, https://linux.die.net/man/1/base64
+CA_BUNDLE=$(cat $(step path)/certs/root_ca.crt | base64 -w 0)
 
 cat <<EOF | kubectl apply -f -
 apiVersion: admissionregistration.k8s.io/v1beta1


### PR DESCRIPTION
### Description
Don't manually remove line-breaks. 
This is more portable in case the OS being run on has different line wrappings.