### PR TITLE
Update to step-cli 0.15.0

### DIFF
--- a/bootstrapper/Dockerfile
+++ b/bootstrapper/Dockerfile
@@ -1,4 +1,4 @@
-FROM smallstep/step-cli:0.14.2
+FROM smallstep/step-cli:0.15.0
 
 USER root
 ENV CRT="/var/run/autocert.step.sm/site.crt"


### PR DESCRIPTION
### Description
This should add support for arm devices as step-cli 0.14.2 currently used doesn't look like to be supporting arm but 0.15.0 does

