### PR TITLE
Kubernetes annotation to use additional sans

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -9,7 +9,7 @@ COPY controller/client.go controller/main.go ./
 RUN go build -o /server .
 
 # final stage
-FROM smallstep/step-cli:0.14.2
+FROM smallstep/step-cli:0.15.0
 ENV STEPPATH="/home/step"
 ENV PWDPATH="/home/step/password/password"
 ENV CONFIGPATH="/home/step/autocert/config.yaml"


### PR DESCRIPTION
When using the autocert.step.sm/name annotation, we cannot specify more than one name. This PR introduces an additional annotation "autocert.step.sm/san" which can be used to generate different alternative names to the certificate. The secret created in the cluster will still use the name value.

My use case is for hashicorp vault HA, where we need several names. E.g.:
```
annotations:
    autocert.step.sm/name: vault
    autocert.step.sm/san: vault-internal.vault.svc,vault-0.vault-internal,vault-1.vault-internal,vault-2.vault-internal,vault-internal.vault,vault-internal.vault.svc
```