### PR TITLE
Use `cr.step.sm` endpoint for image references in k8s install

### DIFF
--- a/install/01-step-ca.yaml
+++ b/install/01-step-ca.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: ca
-        image: smallstep/step-ca:0.10.0
+        image: cr.step.sm/smallstep/step-ca:0.10.0
         env:
         - name: PWDPATH
           value: /home/step/password/password

--- a/install/02-autocert.yaml
+++ b/install/02-autocert.yaml
@@ -27,7 +27,7 @@ data:
     certLifetime: 24h
     renewer:
       name: autocert-renewer
-      image: smallstep/autocert-renewer:0.12.2
+      image: cr.step.sm/smallstep/autocert-renewer:0.12.2
       resources: {requests: {cpu: 10m, memory: 20Mi}}
       imagePullPolicy: IfNotPresent
       volumeMounts:
@@ -35,7 +35,7 @@ data:
         mountPath: /var/run/autocert.step.sm
     bootstrapper:
       name: autocert-bootstrapper
-      image: smallstep/autocert-bootstrapper:0.12.2
+      image: cr.step.sm/smallstep/autocert-bootstrapper:0.12.2
       resources: {requests: {cpu: 10m, memory: 20Mi}}
       imagePullPolicy: IfNotPresent
       volumeMounts:
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: autocert
-        image: smallstep/autocert-controller:0.12.2
+        image: cr.step.sm/smallstep/autocert-controller:0.12.2
         resources: {requests: {cpu: 100m, memory: 20Mi}}
         env:
         - name: PROVISIONER_NAME


### PR DESCRIPTION
### Description

This change updates the `install/*.yaml` files to pull `smallstep/*` docker containers through the new `cr.step.sm` endpoint.

cc @mmalone @alanchrt
