### PR TITLE
Run a custom script at renewal time

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -41,6 +41,7 @@ const (
 	sansAnnotationKey             = "autocert.step.sm/sans"
 	ownerAnnotationKey            = "autocert.step.sm/owner"
 	modeAnnotationKey             = "autocert.step.sm/mode"
+	renewerVolumeAnnotationKey    = "autocert.step.sm/renewer-script"
 	volumeMountPath               = "/var/run/autocert.step.sm"
 	tokenSecretKey                = "token"
 	tokenSecretLabel              = "autocert.step.sm/token"
@@ -330,7 +331,7 @@ func mkBootstrapper(config *Config, podName, commonName, duration, owner, mode, 
 }
 
 // mkRenewer generates a new renewer based on the template provided in Config.
-func mkRenewer(config *Config, podName, commonName, namespace string) corev1.Container {
+func mkRenewer(config *Config, podName, commonName, namespace, renewerVolume string) corev1.Container {
 	r := config.Renewer
 	r.Env = append(r.Env, corev1.EnvVar{
 		Name:  "STEP_CA_URL",
@@ -352,6 +353,15 @@ func mkRenewer(config *Config, podName, commonName, namespace string) corev1.Con
 		Name:  "CLUSTER_DOMAIN",
 		Value: config.ClusterDomain,
 	})
+
+	if (renewerVolume != "") {
+		r.VolumeMounts = append(r.VolumeMounts, corev1.VolumeMount{
+			Name:      renewerVolume,
+			MountPath: "/renewer",
+			ReadOnly:  true,
+		})
+	}
+
 	return r
 }
 
@@ -490,7 +500,8 @@ func patch(pod *corev1.Pod, namespace string, config *Config, provisioner *ca.Pr
 	duration := annotations[durationWebhookStatusKey]
 	owner := annotations[ownerAnnotationKey]
 	mode := annotations[modeAnnotationKey]
-	renewer := mkRenewer(config, name, commonName, namespace)
+	renewerVolume := annotations[renewerVolumeAnnotationKey]
+	renewer := mkRenewer(config, name, commonName, namespace, renewerVolume)
 	bootstrapper, err := mkBootstrapper(config, name, commonName, duration, owner, mode, namespace, sans, provisioner)
 	if err != nil {
 		return nil, err

--- a/renewer/Dockerfile
+++ b/renewer/Dockerfile
@@ -5,4 +5,6 @@ ENV CRT="/var/run/autocert.step.sm/site.crt"
 ENV KEY="/var/run/autocert.step.sm/site.key"
 ENV STEP_ROOT="/var/run/autocert.step.sm/root.crt"
 
-ENTRYPOINT ["/bin/bash", "-c", "step ca renew --daemon $CRT $KEY"]
+COPY renewer/renewer.sh /home/step/
+RUN chmod +x /home/step/renewer.sh
+CMD ["/home/step/renewer.sh"]

--- a/renewer/renewer.sh
+++ b/renewer/renewer.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -e /renew/renew.sh ]
+then
+        CMD="--exec=/renew/renew.sh"
+fi
+
+/bin/bash -xc "step ca renew $CMD --daemon $CRT $KEY"
+

--- a/renewer/renewer.sh
+++ b/renewer/renewer.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-if [ -e /renew/renew.sh ]
+SCRIPT_PATH=/renewer/renew.sh
+
+if [ -e "SCRIPT_PATH" ]
 then
-        CMD="--exec=/renew/renew.sh"
+        CMD="--exec=$SCRIPT_PATH"
 fi
 
 /bin/bash -xc "step ca renew $CMD --daemon $CRT $KEY"
-


### PR DESCRIPTION
Some applications don't notice when their certificates are changed on disk after auto-renewal.

`step ca renew` has an `--exec` option to allow arbitary code to be run at renewal time, but the existing autocert-renewal container doesn't hook into that.

This pach updates autocert-controller to add a volumeMount to the renewal container if the user has created an `autocert.step.sm/renewalVolume` annotation (with a value of the name of the volume to mount).

It also updates autocert-renewal to check for a file at `/renewer/renewal.sh` and, if found, adds an `--exec=/renewer/renewal.sh` option to `step ca renew`.

It's a bit of a hack, I'm not entirely happy with it, but it does work, allowing users to signal the main application in the appropriate way after a renewal.

Feedback/advice/suggestions welcome/encouraged!