### PR TITLE
Use step-ca with step 0.23.0

### DIFF
--- a/install/01-step-ca.yaml
+++ b/install/01-step-ca.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: ca
-        image: cr.step.sm/smallstep/step-ca:0.23.1
+        image: cr.step.sm/smallstep/step-ca:0.23.0
         env:
         - name: PWDPATH
           value: /home/step/password/password


### PR DESCRIPTION
### Description

This PR sets the step-ca version to 0.23.0

step version 0.23.0 doesn't attempt to connect a remote ca, causing an error if this doesn't exist. This caused errors in the init script because the autocert provisioner wasn't created.

Fix in step is https://github.com/smallstep/cli/pull/833