### PR TITLE
Run autocert init with step 0.23.0

### DIFF
--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,4 +1,4 @@
-FROM smallstep/step-cli:0.23.1
+FROM smallstep/step-cli:0.23.0
 
 ENV CA_NAME="Autocert"
 ENV CA_DNS="ca.step.svc.cluster.local,127.0.0.1"

--- a/install/01-step-ca.yaml
+++ b/install/01-step-ca.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: ca
-        image: cr.step.sm/smallstep/step-ca:0.23.0
+        image: cr.step.sm/smallstep/step-ca:0.23.1
         env:
         - name: PWDPATH
           value: /home/step/password/password


### PR DESCRIPTION
### Description

This PR changes the init image to use step 0.23.0.

Version 0.23.1 has a bug that causes errors when editing local ca.json
