### PR TITLE
Replace deprecated GoReleaser --rm-dist flag with --clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: 'latest'
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_PAT }}
           COSIGN_EXPERIMENTAL: 1


### PR DESCRIPTION
See https://github.com/goreleaser/goreleaser/commit/d18adfb57ee951787536b22b62f2a5ebc511c716
