### PR TITLE
fix: make the bootstrapper exit cleanly on subsequent runs

### DIFF
--- a/bootstrapper/bootstrapper.sh
+++ b/bootstrapper/bootstrapper.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+
+if [ -f "$STEP_ROOT" ];
+    echo "Found existing $STEP_ROOT, skipping bootstrap"
+    exit 0
+fi
+
 # Download the root certificate and set permissions
 if [ "$DURATION" == "" ];
 then

--- a/controller/main.go
+++ b/controller/main.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -303,7 +304,8 @@ func mkBootstrapper(config *Config, podName, commonName, duration, owner, mode, 
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: secretName,
 					},
-					Key: tokenSecretKey,
+					Key:      tokenSecretKey,
+					Optional: ptr.To[bool](true),
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	google.golang.org/grpc v1.59.0
 	k8s.io/api v0.29.0-alpha.2
 	k8s.io/apimachinery v0.29.0-alpha.2
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 )
 
 require (
@@ -93,7 +94,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect


### PR DESCRIPTION
#### Name of feature:

Make `autocert-bootstrapper` exit cleanly on subsequent runs

#### Pain or issue this feature alleviates:

Resolve #173 

#### Why is this important to the project (if not answered above):

Hopefully it fixes a bug

#### Is there documentation on how to use this feature? If so, where?

I'm not sure additional documentation is necessary here.

#### In what environments or workflows is this feature supported?

Any environment where pods run for a long time.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?

None specifically

#### Supporting links/other PRs/issues:

According to the Kubernetes docs pods can be restarted for a couple of reasons, and in the current setup the bootstrapper will fail on subsequent runs. https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#pod-restart-reasons

💔Thank you!
