### PR TITLE
Upgrade `k8s.io/api` and `k8s.io/apimachinery`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smallstep/autocert
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/golang/protobuf v1.5.4
@@ -11,8 +11,8 @@ require (
 	go.step.sm/crypto v0.44.8
 	golang.org/x/net v0.24.0
 	google.golang.org/grpc v1.63.2
-	k8s.io/api v0.30.0-alpha.3
-	k8s.io/apimachinery v0.30.0-alpha.3
+	k8s.io/api v0.30.0
+	k8s.io/apimachinery v0.30.0
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -543,10 +543,10 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-k8s.io/api v0.30.0-alpha.3 h1:EcbaDi8WjoR8QdQS6LKd8oP0qjODWxfKdVj5U8WM1P0=
-k8s.io/api v0.30.0-alpha.3/go.mod h1:gUziZ7QreMQgwigIm0O6q1xN4w2DPIs6PwP9Ha3c9dQ=
-k8s.io/apimachinery v0.30.0-alpha.3 h1:9FoqT1Wc+48DJ+mYkbmZd3n4351u9YbGnQSPnVWUwWM=
-k8s.io/apimachinery v0.30.0-alpha.3/go.mod h1:/862Kkwje5hhHGJWPKiaHuov2c6mw6uCXWikV9kOIP4=
+k8s.io/api v0.30.0 h1:siWhRq7cNjy2iHssOB9SCGNCl2spiF1dO3dABqZ8niA=
+k8s.io/api v0.30.0/go.mod h1:OPlaYhoHs8EQ1ql0R/TsUgaRPhpKNxIMrKQfWUp8QSE=
+k8s.io/apimachinery v0.30.0 h1:qxVPsyDM5XS96NIh9Oj6LavoVFYff/Pon9cZeDIkHHA=
+k8s.io/apimachinery v0.30.0/go.mod h1:iexa2somDaxdnj7bha06bhb43Zpa6eWH8N8dbqVjTUc=
 k8s.io/klog/v2 v2.120.1 h1:QXU6cPEOIslTGvZaXvFWiP9VKyeet3sawzTOvdXb4Vw=
 k8s.io/klog/v2 v2.120.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/utils v0.0.0-20231127182322-b307cd553661 h1:FepOBzJ0GXm8t0su67ln2wAZjbQ6RxQGZDnzuLcrUTI=


### PR DESCRIPTION
Replaces #234 and #233 