### PR TITLE
bug: only skip bootstrap when we have certs

### DIFF
--- a/bootstrapper/bootstrapper.sh
+++ b/bootstrapper/bootstrapper.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 
-if [ -f "$STEP_ROOT" ];
+if [ -f "$STEP_ROOT" ] && [ -f "$CRT" ] && [ -f "$KEY" ];
 then
-    echo "Found existing $STEP_ROOT, skipping bootstrap"
+    echo "Found existing $STEP_ROOT, $CRT, and $KEY, skipping bootstrap"
     exit 0
 fi
 


### PR DESCRIPTION
#### Name of feature: Fixing bootstrapper skip logic

#### Pain or issue this feature alleviates:
```
user@NODE:~$ kubectl logs -n namespace service-b577877c9-mfl7v autocert-renewer
error reading certificate chain: : no such file or directory

user@NODE:~$ kubectl logs -n namespace service-b577877c9-mfl7v autocert-bootstrapper
Found existing /var/run/autocert.step.sm/root.crt, skipping bootstrap
```

#### Why is this important to the project (if not answered above):
Because after a node drain running kubernetes deployments, when the node schedules pods again the root cert seems to exist, but the leaf certificate and key does not.  This ends up causing pods to become stuck in CrashLoopBackOff

#### Is there documentation on how to use this feature? If so, where?
N/A

#### In what environments or workflows is this feature supported?
Kubernetes clusters

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
N/A

#### Supporting links/other PRs/issues:
In response to this PR:
https://github.com/smallstep/autocert/pull/174

💔Thank you!
