### PR TITLE
Add support for P12 and PEM formats in bootstrapper and renewer

### DIFF
--- a/bootstrapper/Dockerfile
+++ b/bootstrapper/Dockerfile
@@ -3,6 +3,8 @@ FROM smallstep/step-cli:0.26.0
 USER root
 ENV CRT="/var/run/autocert.step.sm/site.crt"
 ENV KEY="/var/run/autocert.step.sm/site.key"
+ENV P12="/var/run/autocert.step.sm/site.p12"
+ENV PEM="/var/run/autocert.step.sm/site.pem"
 ENV STEP_ROOT="/var/run/autocert.step.sm/root.crt"
 
 COPY bootstrapper/bootstrapper.sh /home/step/

--- a/bootstrapper/bootstrapper.sh
+++ b/bootstrapper/bootstrapper.sh
@@ -8,24 +8,25 @@ then
 fi
 
 # Download the root certificate and set permissions
+step ca root $STEP_ROOT
+
 if [ "$DURATION" == "" ];
 then
     step ca certificate $COMMON_NAME $CRT $KEY
 else
     step ca certificate --not-after $DURATION $COMMON_NAME $CRT $KEY
 fi
-
-step ca root $STEP_ROOT
+cat $CRT $KEY > $PEM
+step certificate p12 $P12 $CRT $KEY --no-password --insecure --force
 
 if [ -n "$OWNER" ]
 then
-    chown "$OWNER" $CRT $KEY $STEP_ROOT
+    chown "$OWNER" $CRT $KEY $STEP_ROOT $P12 $PEM
 fi
 
 if [ -n "$MODE" ]
 then
-    chmod "$MODE" $CRT $KEY $STEP_ROOT
+    chmod "$MODE" $CRT $KEY $STEP_ROOT $P12 $PEM
 else
-    chmod 644 $CRT $KEY $STEP_ROOT
+    chmod 644 $CRT $KEY $STEP_ROOT $P12 $PEM
 fi
-

--- a/renewer/Dockerfile
+++ b/renewer/Dockerfile
@@ -3,6 +3,11 @@ FROM smallstep/step-cli:0.26.0
 USER root
 ENV CRT="/var/run/autocert.step.sm/site.crt"
 ENV KEY="/var/run/autocert.step.sm/site.key"
+ENV P12="/var/run/autocert.step.sm/site.p12"
+ENV PEM="/var/run/autocert.step.sm/site.pem"
 ENV STEP_ROOT="/var/run/autocert.step.sm/root.crt"
 
-ENTRYPOINT ["/bin/bash", "-c", "step ca renew --daemon $CRT $KEY"]
+COPY renewer/renewerexec.sh /home/step/
+RUN chmod +x /home/step/renewerexec.sh
+
+ENTRYPOINT ["/bin/bash", "-c", "step ca renew --daemon --exec /home/step/renewerexec.sh $CRT $KEY"]

--- a/renewer/renewerexec.sh
+++ b/renewer/renewerexec.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat $CRT $KEY > $PEM
+step certificate p12 $P12 $CRT $KEY --no-password --insecure --force


### PR DESCRIPTION
- Introduce P12 and PEM environment variables in Dockerfiles
- Generate P12 and PEM files in bootstrapper.sh
- Update ownership and permissions for new files
- Modify renewer Dockerfile to use new environment variables
- Add renewerexec.sh script to handle renewal with new formats

#### Name of feature:
Introduce P12 and PEM environment variables, certificate generation, and renewal handling in Dockerfiles and scripts.

#### Pain or issue this feature alleviates:
This feature automates the management of P12 and PEM certificate formats in Dockerized environments, ensuring proper handling of SSL/TLS certificates. It simplifies certificate renewal and integration into the containerized application for prisma.io (requires p12 certificate for postgresql),  pem certificate for mongodb

#### Why is this important to the project (if not answered above):
Becouse we are using prisma.io and payloadcms with SSL database connections.

#### Is there documentation on how to use this feature? If so, where?
Example for  mongodb: `tls=true&tlsCertificateKeyFile=/var/run/autocert.step.sm/site.pem&tlsCAFile=/var/run/autocert.step.sm/root.crt&authSource=$external&authMechanism=MONGODB-X509"`
Example for prisma + postgesql: `sslmode=require&sslcert=/var/run/autocert.step.sm/root.crt&sslidentity=/var/run/autocert.step.sm/site.p12`

#### In what environments or workflows is this feature supported?
This feature is supported in any Docker-based environments where certificates need to be generated and renewed, particularly in secure production, staging, and development environments.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
N/A

#### Supporting links/other PRs/issues:
N/A

