### PR TITLE
feat: add configurable certificate mount path support

### DIFF
--- a/CUSTOM_MOUNT_PATH.md
+++ b/CUSTOM_MOUNT_PATH.md
@@ -1,0 +1,89 @@
+# Autocert Configuration
+
+## Configurable Mount Path
+
+By default, autocert mounts certificates at `/var/run/autocert.step.sm/`. You can now customize this path using annotations.
+
+### Usage
+
+Add the `autocert.step.sm/mount-path` annotation to your pod:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    metadata:
+      annotations:
+        autocert.step.sm/name: my-app.default.svc.cluster.local
+        autocert.step.sm/mount-path: /custom/cert/path
+    spec:
+      containers:
+      - name: app
+        image: my-app:latest
+```
+## Default Behavior
+
+Without annotation: /var/run/autocert.step.sm/
+With annotation: Your specified custom path
+
+## File Structure
+Certificates will be available at:
+
+<mount-path>/site.crt
+<mount-path>/site.key
+<mount-path>/root.crt
+
+### Important: Custom Controller Image Required
+Note: This configurable mount path feature requires an updated controller image that is not yet available in the official repository. To use this feature, you need to:
+## 1 Build Custom Controller Image
+Since the original YAML files haven't been updated with the new images, you'll need to build and use custom Docker images with the updated code:
+```bash
+docker build -t your-registry/autocert-controller:custom -f controller/Dockerfile .
+```
+## 2 Load image to cluster
+```bash
+#for minikube:
+minikube image load autocert-controller:custom
+
+#for kind
+kind load docker-image autocert-controller:custom --name <your cluster name>
+```
+## 3 Update Controller Deployment
+Update the autocert controller deployment to use your custom image:
+
+```bash
+#restart deployment(if needed)
+kubectl rollout restart deployment/<your-deployment-name>
+#For local clusters (minikube, kind, Docker Desktop):
+kubectl patch deployment autocert -n step -p '{"spec":{"template":{"spec":{"containers":[{"name":"autocert","image":"autocert-controller:custom","imagePullPolicy":"Never"}]}}}}'
+
+#For remote clusters using registry
+kubectl patch deployment autocert -n step -p '{"spec":{"template":{"spec":{"containers":[{"name":"autocert","image":"your-registry/autocert-controller:custom"}]}}}}'
+```
+## 4 Verify Deployment
+Check that the controller is running with the new image:
+
+```bash
+# Check deployment status
+kubectl get deployment autocert -n step
+
+# Check pod is running
+kubectl get pods -n step -l app=autocert
+
+# Verify the new image is being used
+kubectl describe deployment autocert -n step | grep Image
+```
+
+# 5 Verification
+After updating the controller image, verify the feature works by:
+Deploying a pod with the custom mount path annotation
+Checking that certificates are mounted at your specified path
+Verifying the application can access certificates at the new location
+
+```bash
+# Check if certificates are at custom path
+kubectl exec -it <your-pod> -- ls -la /custom/cert/path/
+```

--- a/controller/main_test.go
+++ b/controller/main_test.go
@@ -83,25 +83,29 @@ func Test_mkRenewer(t *testing.T) {
 		podName    string
 		commonName string
 		namespace  string
+		mountPath  string
 	}
 	tests := []struct {
 		name string
 		args args
 		want corev1.Container
 	}{
-		{"ok", args{&Config{CaURL: "caURL", ClusterDomain: "clusterDomain"}, "podName", "commonName", "namespace"}, corev1.Container{
+		{"ok", args{&Config{CaURL: "caURL", ClusterDomain: "clusterDomain"}, "podName", "commonName", "namespace", "/var/run/autocert.step.sm"}, corev1.Container{
 			Env: []corev1.EnvVar{
 				{Name: "STEP_CA_URL", Value: "caURL"},
 				{Name: "COMMON_NAME", Value: "commonName"},
 				{Name: "POD_NAME", Value: "podName"},
 				{Name: "NAMESPACE", Value: "namespace"},
 				{Name: "CLUSTER_DOMAIN", Value: "clusterDomain"},
+				{Name: "CRT", Value: "/var/run/autocert.step.sm/site.crt"},
+				{Name: "KEY", Value: "/var/run/autocert.step.sm/site.key"},
+				{Name: "STEP_ROOT", Value: "/var/run/autocert.step.sm/root.crt"},
 			},
 		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := mkRenewer(tt.args.config, tt.args.podName, tt.args.commonName, tt.args.namespace); !reflect.DeepEqual(got, tt.want) {
+			if got := mkRenewer(tt.args.config, tt.args.podName, tt.args.commonName, tt.args.namespace, tt.args.mountPath); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("mkRenewer() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Summary
Adds support for configurable certificate mount paths via the `autocert.step.sm/mount-path` annotation, enabling integration with Istio and other applications that require certificates in specific locations.

#### Name of feature:
Configurable Certificate Mount Path

#### Pain or issue this feature alleviates:
- Enables integration with Istio service mesh, which expects certificates at specific paths
- Provides flexibility for applications that need certificates mounted at custom locations
- Eliminates need for symlinks or file copying to work with different certificate expectations

#### Why is this important to the project:
- Expands autocert compatibility with service mesh technologies like Istio
- Makes autocert more flexible and adaptable to different deployment scenarios
- Addresses a specific user request for Istio integration (#256)

#### Is there documentation on how to use this feature? If so, where?
Yes, comprehensive documentation is provided in `CUSTOM_MOUNT_PATH.md` including:
- Usage examples with annotations
- Custom controller image build instructions
- Deployment update procedures
- Verification steps

#### In what environments or workflows is this feature supported?
- All Kubernetes environments (local and remote clusters)
- Particularly useful for Istio service mesh deployments
- Compatible with existing autocert functionality
- Works with minikube, kind, GKE, EKS, AKS, etc.

#### In what environments or workflows is this feature explicitly NOT supported (if any)?
- Requires custom controller image build until officially released
- No known compatibility restrictions otherwise

#### Supporting links/other PRs/issues:
Fixes #256

## Usage Example
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-app
spec:
  template:
    metadata:
      annotations:
        autocert.step.sm/name: my-app.default.svc.cluster.local
        autocert.step.sm/mount-path: /etc/ssl/certs
    spec:
      containers:
      - name: app
        image: my-app:latest

💔Thank you!
