### PR TITLE
Grant CI job required permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ permissions:
 
 jobs:
   ci:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: smallstep/autocert/.github/workflows/ci.yml@master
     secrets: inherit
 


### PR DESCRIPTION
The ci job was inheriting only `contents: read` from the top-level permissions, but the called ci.yml workflow needs `actions: read` and `security-events: write` (for CodeQL). Caller permissions cap what reusable workflows can use, so those were silently denied.

Change-Type: ci
Release-Note: no
Audience: internal
Impact: low
Breaking: false

