### PR TITLE
Group Dependabot updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,22 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  ## GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/"
+      interval: weekly
+    groups:
+      # group patch updates
+      all:
+        update-types: [ patch, minor, major ]
+
+  ## Go
+  - package-ecosystem: gomod
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    groups:
+      all:
+        update-types: [ patch, minor ]


### PR DESCRIPTION
Configures update groups for both GitHub Actions and Go module ecosystems so that related dependency updates are batched into fewer PRs. GitHub Actions groups all update types; Go modules group patch and minor updates only.

Change-Type: ci
Release-Note: no
Audience: developer
Impact: none
Breaking: false
